### PR TITLE
Fix ModMenu compatibility

### DIFF
--- a/src/main/java/com/mrcrayfish/menulogue/integration/CatalogueConfigFactory.java
+++ b/src/main/java/com/mrcrayfish/menulogue/integration/CatalogueConfigFactory.java
@@ -26,10 +26,12 @@ public class CatalogueConfigFactory
             {
                 ModMenuApi entry = container.getEntrypoint();
                 ConfigScreenFactory<?> factory = entry.getModConfigScreenFactory();
+                if (factory == null) return;
                 providers.put(modId, (previousScreen, modContainer) -> {
                     return factory.create(previousScreen);
                 });
                 entry.getProvidedConfigScreenFactories().forEach((s, f) -> {
+                    if (f == null) return;
                     providers.putIfAbsent(s, (previousScreen, modContainer) -> {
                         return f.create(previousScreen);
                     });


### PR DESCRIPTION
`ConfigScreenFactory` factory in ModMenu is allowed to be null, in which case the entry is skipped. This behavior is intentional and allows mods to have optional dependencies on config libraries.  
I.e. if you return null in `getModConfigScreenFactory()` it means "I would like to be compatible with modmenu, but can't rn".

This PR adds this check to the mod to replicate the behavior and fix a crash when a mod follows this pattern.